### PR TITLE
Fix typo for alignment.beforeSave

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
                     "description": "A glob pattern that defines files to exclude while listing annotations"
                 },
                 "alignment.beforeSave": {
-                    "type": "Boolean",
+                    "type": "boolean",
                     "enum": [
                         true,
                         false


### PR DESCRIPTION
  alignment.beforeSave had a typo on boolean type, which was causing an error on user settings.json

To replicate just set alignment.beforeSave to false or copy it to user settings.json and the issue will be visible.